### PR TITLE
ki2-parserの「寄」のバグ修正

### DIFF
--- a/out/ki2-parser.js
+++ b/out/ki2-parser.js
@@ -2071,7 +2071,7 @@ JKFPlayer.ki2Parser = (function() {
     	function dousaToRelative(str){
     		return {
     			"上": "U",
-    			"寄": "C",
+    			"寄": "M",
     			"引": "D",
     		}[str] || "";
     	}

--- a/out/kifuplayer.js
+++ b/out/kifuplayer.js
@@ -6025,7 +6025,7 @@ JKFPlayer.ki2Parser = (function() {
     	function dousaToRelative(str){
     		return {
     			"上": "U",
-    			"寄": "C",
+    			"寄": "M",
     			"引": "D",
     		}[str] || "";
     	}

--- a/src/ki2-parser.pegjs
+++ b/src/ki2-parser.pegjs
@@ -55,7 +55,7 @@
 	function dousaToRelative(str){
 		return {
 			"上": "U",
-			"寄": "C",
+			"寄": "M",
 			"引": "D",
 		}[str] || "";
 	}


### PR DESCRIPTION
便利に使わせていただいております。
KI2形式で「寄」が「直」としてパースされるバグがあることに気づいたので修正してみました。
ご確認よろしくお願いいたします。

参考棋譜
```
先手：先手
後手：後手

▲５八金右△３四歩▲６八金寄△８四歩▲５八飛
```