### PR TITLE
Fix Missing dependency 'vinyl-source-stream'

### DIFF
--- a/package.json
+++ b/package.json
@@ -38,7 +38,8 @@
     "iconv": "^2.1.8",
     "jschardet": "^1.3.0",
     "merge2": "^0.3.6",
-    "typescript": "^1.5.3"
+    "typescript": "^1.5.3",
+    "vinyl-source-stream": "^1.1.0"
   },
   "dependencies": {
     "shogi.js": "^1.0.0"


### PR DESCRIPTION
# Issue

https://github.com/na2hiro/json-kifu-format/issues/24 の対応

## 対応

`npm install vinyl-source-stream --save-dev`でpackage.jsonを更新しました。