### PR TITLE
fix import path

### DIFF
--- a/lib/jkfplayer.d.ts
+++ b/lib/jkfplayer.d.ts
@@ -4,7 +4,7 @@
  * This software is released under the MIT License.
  * http://opensource.org/licenses/mit-license.php
  */
-import ShogiJS = require('../node_modules/shogi.js/lib/shogi');
+import ShogiJS = require('shogi.js/lib/shogi');
 import Shogi = ShogiJS.Shogi;
 import JKF = require('./JSONKifuFormat');
 export = JKFPlayer;

--- a/lib/jkfplayer.js
+++ b/lib/jkfplayer.js
@@ -1,10 +1,11 @@
+"use strict";
 /** @license
  * JSON Kifu Format
  * Copyright (c) 2014 na2hiro (https://github.com/na2hiro)
  * This software is released under the MIT License.
  * http://opensource.org/licenses/mit-license.php
  */
-var ShogiJS = require('../node_modules/shogi.js/lib/shogi');
+var ShogiJS = require('shogi.js/lib/shogi');
 var Color = ShogiJS.Color;
 var Piece = ShogiJS.Piece;
 var Shogi = ShogiJS.Shogi;
@@ -395,5 +396,5 @@ var JKFPlayer = (function () {
     JKFPlayer.debug = false;
     JKFPlayer._log = [];
     return JKFPlayer;
-})();
+}());
 module.exports = JKFPlayer;

--- a/lib/normalizer.d.ts
+++ b/lib/normalizer.d.ts
@@ -4,7 +4,7 @@
  * This software is released under the MIT License.
  * http://opensource.org/licenses/mit-license.php
  */
-import ShogiJS = require("../node_modules/shogi.js/lib/shogi");
+import ShogiJS = require("shogi.js/lib/shogi");
 import Color = ShogiJS.Color;
 import JKF = require('./JSONKifuFormat');
 export declare function canPromote(place: JKF.PlaceFormat, color: Color): boolean;

--- a/lib/normalizer.js
+++ b/lib/normalizer.js
@@ -1,10 +1,11 @@
+"use strict";
 /** @license
  * JSON Kifu Format
  * Copyright (c) 2014 na2hiro (https://github.com/na2hiro)
  * This software is released under the MIT License.
  * http://opensource.org/licenses/mit-license.php
  */
-var ShogiJS = require("../node_modules/shogi.js/lib/shogi");
+var ShogiJS = require("shogi.js/lib/shogi");
 var Shogi = ShogiJS.Shogi;
 var Piece = ShogiJS.Piece;
 var Color = ShogiJS.Color;

--- a/src/JSONKifuFormat.d.ts
+++ b/src/JSONKifuFormat.d.ts
@@ -4,7 +4,7 @@
  * This software is released under the MIT License.
  * http://opensource.org/licenses/mit-license.php
  */
- import ShogiJS = require("../node_modules/shogi.js/lib/shogi");
+ import ShogiJS = require("shogi.js/lib/shogi");
  import Color = ShogiJS.Color;
 export interface JSONKifuFormat{
 	header: {[index: string]: string;};

--- a/src/jkfplayer.ts
+++ b/src/jkfplayer.ts
@@ -4,7 +4,7 @@
  * This software is released under the MIT License.
  * http://opensource.org/licenses/mit-license.php
  */
-import ShogiJS = require('../node_modules/shogi.js/lib/shogi');
+import ShogiJS = require('shogi.js/lib/shogi');
 import Color = ShogiJS.Color;
 import Piece = ShogiJS.Piece;
 import Shogi = ShogiJS.Shogi;

--- a/src/normalizer.ts
+++ b/src/normalizer.ts
@@ -1,10 +1,10 @@
 /** @license
- * JSON Kifu Format 
+ * JSON Kifu Format
  * Copyright (c) 2014 na2hiro (https://github.com/na2hiro)
  * This software is released under the MIT License.
  * http://opensource.org/licenses/mit-license.php
  */
-import ShogiJS = require("../node_modules/shogi.js/lib/shogi");
+import ShogiJS = require("shogi.js/lib/shogi");
 import Shogi = ShogiJS.Shogi;
 import Piece = ShogiJS.Piece;
 import Color = ShogiJS.Color;


### PR DESCRIPTION
他プロジェクトから `json-kifu-format` や `lib/kifu-parser` などを import した際に、下記エラーが発生します。

```
ERROR in /XXX/~/json-kifu-format/lib/jkfplayer.js
Module not found: Error: Cannot resolve 'file' or 'directory' ../node_modules/shogi.js/lib/shogi in /XXX/node_modules/json-kifu-format/lib
 @ /XXX/~/json-kifu-format/lib/jkfplayer.js 7:14-59

ERROR in /XXX/~/json-kifu-format/lib/normalizer.js
Module not found: Error: Cannot resolve 'file' or 'directory' ../node_modules/shogi.js/lib/shogi in /XXX/node_modules/json-kifu-format/lib
 @ /XXX/~/json-kifu-format/lib/normalizer.js 7:14-59
```

shogi.js の import 方法を変更することで、正常動作するようです。
ご確認くださいm(_ _)m

ご参考: https://github.com/na-o-ys/kento/blob/master/src/javascripts/lib/game.js#L1