### PR TITLE
Fix TypeError in JKFPlayer.sameMoveMinimal()

### DIFF
--- a/lib/jkfplayer.js
+++ b/lib/jkfplayer.js
@@ -1,3 +1,4 @@
+"use strict";
 /** @license
  * JSON Kifu Format
  * Copyright (c) 2014 na2hiro (https://github.com/na2hiro)
@@ -395,5 +396,5 @@ var JKFPlayer = (function () {
     JKFPlayer.debug = false;
     JKFPlayer._log = [];
     return JKFPlayer;
-})();
+}());
 module.exports = JKFPlayer;

--- a/lib/jkfplayer.js
+++ b/lib/jkfplayer.js
@@ -370,7 +370,7 @@ var JKFPlayer = (function () {
     };
     JKFPlayer.sameMoveMinimal = function (move1, move2) {
         return (move1.to.x == move2.to.x && move1.to.y == move2.to.y
-            && (move1.from
+            && (move1.from && move2.from
                 ? move1.from.x == move2.from.x && move1.from.y == move2.from.y && move1.promote == move2.promote
                 : move1.piece == move2.piece));
     };

--- a/lib/normalizer.js
+++ b/lib/normalizer.js
@@ -1,3 +1,4 @@
+"use strict";
 /** @license
  * JSON Kifu Format
  * Copyright (c) 2014 na2hiro (https://github.com/na2hiro)

--- a/out/jkfplayer.js
+++ b/out/jkfplayer.js
@@ -7793,7 +7793,7 @@ var JKFPlayer = (function () {
     };
     JKFPlayer.sameMoveMinimal = function (move1, move2) {
         return (move1.to.x == move2.to.x && move1.to.y == move2.to.y
-            && (move1.from
+            && (move1.from && move2.from
                 ? move1.from.x == move2.from.x && move1.from.y == move2.from.y && move1.promote == move2.promote
                 : move1.piece == move2.piece));
     };

--- a/out/jkfplayer.js
+++ b/out/jkfplayer.js
@@ -6367,6 +6367,7 @@ module.exports = (function() {
   };
 })();
 },{}],4:[function(require,module,exports){
+"use strict";
 /** @license
  * JSON Kifu Format
  * Copyright (c) 2014 na2hiro (https://github.com/na2hiro)
@@ -7421,6 +7422,7 @@ var Piece = (function () {
 exports.Piece = Piece;
 
 },{}],"JKFPlayer":[function(require,module,exports){
+"use strict";
 /** @license
  * JSON Kifu Format
  * Copyright (c) 2014 na2hiro (https://github.com/na2hiro)
@@ -7818,7 +7820,7 @@ var JKFPlayer = (function () {
     JKFPlayer.debug = false;
     JKFPlayer._log = [];
     return JKFPlayer;
-})();
+}());
 module.exports = JKFPlayer;
 
 },{"../lib/csa-parser":1,"../lib/ki2-parser":2,"../lib/kif-parser":3,"./normalizer":4,"shogi.js/lib/shogi":5}]},{},[]);

--- a/src/jkfplayer.ts
+++ b/src/jkfplayer.ts
@@ -344,7 +344,7 @@ class JKFPlayer{
 	}
 	private static sameMoveMinimal(move1: JKF.MoveMoveFormat, move2: JKF.MoveMoveFormat){
 		return (move1.to.x==move2.to.x && move1.to.y==move2.to.y
-						&& (move1.from
+						&& (move1.from && move2.from
 							? move1.from.x==move2.from.x && move1.from.y==move2.from.y && move1.promote==move2.promote
 							: move1.piece==move2.piece ));
 	}

--- a/test/jkfplayerTest.js
+++ b/test/jkfplayerTest.js
@@ -411,5 +411,6 @@ P-\n\
 		assert(JKFPlayer.sameMoveMinimal({to:p(2,3),piece:"KY"}, {to:p(2,3),piece:"KY"}));
 		assert.equal(JKFPlayer.sameMoveMinimal({from:p(2,3),to:p(2,2),promote:false}, {from:p(2,3),to:p(2,2),promote:true, piece:"FU"}), false);
 		assert.equal(JKFPlayer.sameMoveMinimal({to:p(2,3),piece:"KE"}, {to:p(2,3),piece:"KY"}), false);
+		assert.equal(JKFPlayer.sameMoveMinimal({from:p(2,7),to:p(2,6),piece:"FU"}, {to:p(2,6),piece:"KA"}), false);
 	});
 });


### PR DESCRIPTION
以下の問題を修正しました。

## 問題

以下の2つの条件を満たす時に `JKFPlayer.sameMoveMinimal()` で `TypeError: Cannot read property 'x' of undefined` という例外が発生します。

1. `move1.to`と`move2.to`が同じ
2. `move2`に`from`がない（持ち駒から打つ）

この条件は、`JKFPlayer.prototype.inputMove()`の観点で言えば次のようになります。

1. 現在の局面で既に次の手（例: ２六歩）が存在する
2. 次の手と同じ場所に持ち駒から打とうとする（例: ２六角）

### 参考

参考として問題を再現できるJKFファイルを作成しました。以下のファイルを[Kifu for JS](https://github.com/na2hiro/Kifu-for-JS)で開き、4手目の☖２二同銀の局面で先手が持ち駒から☗２六角を打とうとしても打てません。

[reproducible_example.txt](https://github.com/na2hiro/json-kifu-format/files/943242/reproducible_example.txt)

## コミットについて

2つ目のコミット https://github.com/orangain/json-kifu-format/commit/224f99b6447025169c370f61dc8d673edb7b89d7 はビルドツール周りのバージョンが微妙に違うせいか生まれた本質的でないdiffです（READMEにあるように`npm install`しただけですが）。もし気になるようでしたら1つ目のコミット https://github.com/orangain/json-kifu-format/commit/b85b93056768d56a6606309dc59c2fad6bbef766 だけを取り込んでいただいても構いません。