### PR TITLE
JSON Schemaによるjson-kifu-formatの仕様の記述

### DIFF
--- a/README.md
+++ b/README.md
@@ -103,6 +103,10 @@ JSONで将棋の棋譜を取り扱う標準形式JKFを定義しています．�
 ### 文字コード
 JSONで一般的なUTF-8を使用するものとします．
 
+### JSON Schemaによる定義
+[JSON Schema](https://json-schema.org/) のバージョン 2020-12 による定義が `specification/json-kifu-format.schema.json` にあります。
+また、 `npm run schema:compile` によりこのJSON Schemaファイル自体の検証を、 `npm run schema:validate` により `test/files/jkf/*.jkf` のJSON Schemaファイルに対する検証を行います。
+
 ## JKFの例
 `test/`以下にも例が載っています．
 ### 通常

--- a/package-lock.json
+++ b/package-lock.json
@@ -14,6 +14,7 @@
       "devDependencies": {
         "@types/jest": "^27.4.0",
         "@types/node": "^13.1.1",
+        "ajv-cli": "^5.0.0",
         "clean-webpack-plugin": "^0.1.19",
         "iconv-lite": "^0.6.3",
         "jest": "^26.6.3",
@@ -2068,6 +2069,54 @@
         "url": "https://github.com/sponsors/epoberezkin"
       }
     },
+    "node_modules/ajv-cli": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/ajv-cli/-/ajv-cli-5.0.0.tgz",
+      "integrity": "sha512-LY4m6dUv44HTyhV+u2z5uX4EhPYTM38Iv1jdgDJJJCyOOuqB8KtZEGjPZ2T+sh5ZIJrXUfgErYx/j3gLd3+PlQ==",
+      "dev": true,
+      "dependencies": {
+        "ajv": "^8.0.0",
+        "fast-json-patch": "^2.0.0",
+        "glob": "^7.1.0",
+        "js-yaml": "^3.14.0",
+        "json-schema-migrate": "^2.0.0",
+        "json5": "^2.1.3",
+        "minimist": "^1.2.0"
+      },
+      "bin": {
+        "ajv": "dist/index.js"
+      },
+      "peerDependencies": {
+        "ts-node": ">=9.0.0"
+      },
+      "peerDependenciesMeta": {
+        "ts-node": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/ajv-cli/node_modules/ajv": {
+      "version": "8.10.0",
+      "resolved": "https://registry.npmjs.org/ajv/-/ajv-8.10.0.tgz",
+      "integrity": "sha512-bzqAEZOjkrUMl2afH8dknrq5KEk2SrwdBROR+vH1EKVQTqaUbJVPdc/gEdggTMM0Se+s+Ja4ju4TlNcStKl2Hw==",
+      "dev": true,
+      "dependencies": {
+        "fast-deep-equal": "^3.1.1",
+        "json-schema-traverse": "^1.0.0",
+        "require-from-string": "^2.0.2",
+        "uri-js": "^4.2.2"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/epoberezkin"
+      }
+    },
+    "node_modules/ajv-cli/node_modules/json-schema-traverse": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/json-schema-traverse/-/json-schema-traverse-1.0.0.tgz",
+      "integrity": "sha512-NM8/P9n3XjXhIZn1lLhkFaACTOURQXjWhV4BA/RnOv8xvgqtqpAX9IO4mRQxSx1Rlo4tqzeqb0sOlruaOy3dug==",
+      "dev": true
+    },
     "node_modules/ajv-keywords": {
       "version": "3.5.2",
       "resolved": "https://registry.npmjs.org/ajv-keywords/-/ajv-keywords-3.5.2.tgz",
@@ -3968,6 +4017,24 @@
       "version": "3.1.3",
       "resolved": "https://registry.npmjs.org/fast-deep-equal/-/fast-deep-equal-3.1.3.tgz",
       "integrity": "sha512-f3qQ9oQy9j2AhBe/H9VC91wLmKBCCU/gDOnKNAYG5hswO7BLKj09Hc5HYNz9cGI++xlpDCIgDaitVs03ATR84Q==",
+      "dev": true
+    },
+    "node_modules/fast-json-patch": {
+      "version": "2.2.1",
+      "resolved": "https://registry.npmjs.org/fast-json-patch/-/fast-json-patch-2.2.1.tgz",
+      "integrity": "sha512-4j5uBaTnsYAV5ebkidvxiLUYOwjQ+JSFljeqfTxCrH9bDmlCQaOJFS84oDJ2rAXZq2yskmk3ORfoP9DCwqFNig==",
+      "dev": true,
+      "dependencies": {
+        "fast-deep-equal": "^2.0.1"
+      },
+      "engines": {
+        "node": ">= 0.4.0"
+      }
+    },
+    "node_modules/fast-json-patch/node_modules/fast-deep-equal": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/fast-deep-equal/-/fast-deep-equal-2.0.1.tgz",
+      "integrity": "sha1-ewUhjd+WZ79/Nwv3/bLLFf3Qqkk=",
       "dev": true
     },
     "node_modules/fast-json-stable-stringify": {
@@ -7910,6 +7977,37 @@
       "integrity": "sha512-xyFwyhro/JEof6Ghe2iz2NcXoj2sloNsWr/XsERDK/oiPCfaNhl5ONfp+jQdAZRQQ0IJWNzH9zIZF7li91kh2w==",
       "dev": true
     },
+    "node_modules/json-schema-migrate": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/json-schema-migrate/-/json-schema-migrate-2.0.0.tgz",
+      "integrity": "sha512-r38SVTtojDRp4eD6WsCqiE0eNDt4v1WalBXb9cyZYw9ai5cGtBwzRNWjHzJl38w6TxFkXAIA7h+fyX3tnrAFhQ==",
+      "dev": true,
+      "dependencies": {
+        "ajv": "^8.0.0"
+      }
+    },
+    "node_modules/json-schema-migrate/node_modules/ajv": {
+      "version": "8.10.0",
+      "resolved": "https://registry.npmjs.org/ajv/-/ajv-8.10.0.tgz",
+      "integrity": "sha512-bzqAEZOjkrUMl2afH8dknrq5KEk2SrwdBROR+vH1EKVQTqaUbJVPdc/gEdggTMM0Se+s+Ja4ju4TlNcStKl2Hw==",
+      "dev": true,
+      "dependencies": {
+        "fast-deep-equal": "^3.1.1",
+        "json-schema-traverse": "^1.0.0",
+        "require-from-string": "^2.0.2",
+        "uri-js": "^4.2.2"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/epoberezkin"
+      }
+    },
+    "node_modules/json-schema-migrate/node_modules/json-schema-traverse": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/json-schema-traverse/-/json-schema-traverse-1.0.0.tgz",
+      "integrity": "sha512-NM8/P9n3XjXhIZn1lLhkFaACTOURQXjWhV4BA/RnOv8xvgqtqpAX9IO4mRQxSx1Rlo4tqzeqb0sOlruaOy3dug==",
+      "dev": true
+    },
     "node_modules/json-schema-traverse": {
       "version": "0.4.1",
       "resolved": "https://registry.npmjs.org/json-schema-traverse/-/json-schema-traverse-0.4.1.tgz",
@@ -9039,6 +9137,15 @@
       "version": "2.1.1",
       "resolved": "https://registry.npmjs.org/require-directory/-/require-directory-2.1.1.tgz",
       "integrity": "sha1-jGStX9MNqxyXbiNE/+f3kqam30I=",
+      "dev": true,
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/require-from-string": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/require-from-string/-/require-from-string-2.0.2.tgz",
+      "integrity": "sha512-Xf0nWe6RseziFMu+Ap9biiUbmplq6S9/p+7w7YXP/JBHhrUDDUhwa+vANyubuqfZWTveU//DYVGsDG7RKL/vEw==",
       "dev": true,
       "engines": {
         "node": ">=0.10.0"
@@ -13116,6 +13223,41 @@
         "uri-js": "^4.2.2"
       }
     },
+    "ajv-cli": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/ajv-cli/-/ajv-cli-5.0.0.tgz",
+      "integrity": "sha512-LY4m6dUv44HTyhV+u2z5uX4EhPYTM38Iv1jdgDJJJCyOOuqB8KtZEGjPZ2T+sh5ZIJrXUfgErYx/j3gLd3+PlQ==",
+      "dev": true,
+      "requires": {
+        "ajv": "^8.0.0",
+        "fast-json-patch": "^2.0.0",
+        "glob": "^7.1.0",
+        "js-yaml": "^3.14.0",
+        "json-schema-migrate": "^2.0.0",
+        "json5": "^2.1.3",
+        "minimist": "^1.2.0"
+      },
+      "dependencies": {
+        "ajv": {
+          "version": "8.10.0",
+          "resolved": "https://registry.npmjs.org/ajv/-/ajv-8.10.0.tgz",
+          "integrity": "sha512-bzqAEZOjkrUMl2afH8dknrq5KEk2SrwdBROR+vH1EKVQTqaUbJVPdc/gEdggTMM0Se+s+Ja4ju4TlNcStKl2Hw==",
+          "dev": true,
+          "requires": {
+            "fast-deep-equal": "^3.1.1",
+            "json-schema-traverse": "^1.0.0",
+            "require-from-string": "^2.0.2",
+            "uri-js": "^4.2.2"
+          }
+        },
+        "json-schema-traverse": {
+          "version": "1.0.0",
+          "resolved": "https://registry.npmjs.org/json-schema-traverse/-/json-schema-traverse-1.0.0.tgz",
+          "integrity": "sha512-NM8/P9n3XjXhIZn1lLhkFaACTOURQXjWhV4BA/RnOv8xvgqtqpAX9IO4mRQxSx1Rlo4tqzeqb0sOlruaOy3dug==",
+          "dev": true
+        }
+      }
+    },
     "ajv-keywords": {
       "version": "3.5.2",
       "resolved": "https://registry.npmjs.org/ajv-keywords/-/ajv-keywords-3.5.2.tgz",
@@ -14627,6 +14769,23 @@
       "resolved": "https://registry.npmjs.org/fast-deep-equal/-/fast-deep-equal-3.1.3.tgz",
       "integrity": "sha512-f3qQ9oQy9j2AhBe/H9VC91wLmKBCCU/gDOnKNAYG5hswO7BLKj09Hc5HYNz9cGI++xlpDCIgDaitVs03ATR84Q==",
       "dev": true
+    },
+    "fast-json-patch": {
+      "version": "2.2.1",
+      "resolved": "https://registry.npmjs.org/fast-json-patch/-/fast-json-patch-2.2.1.tgz",
+      "integrity": "sha512-4j5uBaTnsYAV5ebkidvxiLUYOwjQ+JSFljeqfTxCrH9bDmlCQaOJFS84oDJ2rAXZq2yskmk3ORfoP9DCwqFNig==",
+      "dev": true,
+      "requires": {
+        "fast-deep-equal": "^2.0.1"
+      },
+      "dependencies": {
+        "fast-deep-equal": {
+          "version": "2.0.1",
+          "resolved": "https://registry.npmjs.org/fast-deep-equal/-/fast-deep-equal-2.0.1.tgz",
+          "integrity": "sha1-ewUhjd+WZ79/Nwv3/bLLFf3Qqkk=",
+          "dev": true
+        }
+      }
     },
     "fast-json-stable-stringify": {
       "version": "2.1.0",
@@ -17711,6 +17870,35 @@
       "integrity": "sha512-xyFwyhro/JEof6Ghe2iz2NcXoj2sloNsWr/XsERDK/oiPCfaNhl5ONfp+jQdAZRQQ0IJWNzH9zIZF7li91kh2w==",
       "dev": true
     },
+    "json-schema-migrate": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/json-schema-migrate/-/json-schema-migrate-2.0.0.tgz",
+      "integrity": "sha512-r38SVTtojDRp4eD6WsCqiE0eNDt4v1WalBXb9cyZYw9ai5cGtBwzRNWjHzJl38w6TxFkXAIA7h+fyX3tnrAFhQ==",
+      "dev": true,
+      "requires": {
+        "ajv": "^8.0.0"
+      },
+      "dependencies": {
+        "ajv": {
+          "version": "8.10.0",
+          "resolved": "https://registry.npmjs.org/ajv/-/ajv-8.10.0.tgz",
+          "integrity": "sha512-bzqAEZOjkrUMl2afH8dknrq5KEk2SrwdBROR+vH1EKVQTqaUbJVPdc/gEdggTMM0Se+s+Ja4ju4TlNcStKl2Hw==",
+          "dev": true,
+          "requires": {
+            "fast-deep-equal": "^3.1.1",
+            "json-schema-traverse": "^1.0.0",
+            "require-from-string": "^2.0.2",
+            "uri-js": "^4.2.2"
+          }
+        },
+        "json-schema-traverse": {
+          "version": "1.0.0",
+          "resolved": "https://registry.npmjs.org/json-schema-traverse/-/json-schema-traverse-1.0.0.tgz",
+          "integrity": "sha512-NM8/P9n3XjXhIZn1lLhkFaACTOURQXjWhV4BA/RnOv8xvgqtqpAX9IO4mRQxSx1Rlo4tqzeqb0sOlruaOy3dug==",
+          "dev": true
+        }
+      }
+    },
     "json-schema-traverse": {
       "version": "0.4.1",
       "resolved": "https://registry.npmjs.org/json-schema-traverse/-/json-schema-traverse-0.4.1.tgz",
@@ -18591,6 +18779,12 @@
       "version": "2.1.1",
       "resolved": "https://registry.npmjs.org/require-directory/-/require-directory-2.1.1.tgz",
       "integrity": "sha1-jGStX9MNqxyXbiNE/+f3kqam30I=",
+      "dev": true
+    },
+    "require-from-string": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/require-from-string/-/require-from-string-2.0.2.tgz",
+      "integrity": "sha512-Xf0nWe6RseziFMu+Ap9biiUbmplq6S9/p+7w7YXP/JBHhrUDDUhwa+vANyubuqfZWTveU//DYVGsDG7RKL/vEw==",
       "dev": true
     },
     "require-main-filename": {

--- a/package.json
+++ b/package.json
@@ -18,7 +18,9 @@
     "typecheck": "tsc --project tsconfig.typecheck.json --noEmit",
     "prepublishOnly": "npm run build",
     "docs": "typedoc --exclude '**/__tests__/**/*' src/main.ts",
-    "deploy:ghpages": "rm -rf ./public && mkdir -p ./public && npm run docs && mv ./docs ./public/"
+    "deploy:ghpages": "rm -rf ./public && mkdir -p ./public && npm run docs && mv ./docs ./public/",
+    "schema:compile": "ajv compile --spec=draft2020 --strict-tuples=false -s specification/json-kifu-format.schema.json",
+    "schema:validate": "ajv validate --spec=draft2020 --strict-tuples=false -s specification/json-kifu-format.schema.json -d 'specification/files/*.json'"
   },
   "repository": {
     "type": "git",
@@ -40,6 +42,7 @@
   "devDependencies": {
     "@types/jest": "^27.4.0",
     "@types/node": "^13.1.1",
+    "ajv-cli": "^5.0.0",
     "clean-webpack-plugin": "^0.1.19",
     "iconv-lite": "^0.6.3",
     "jest": "^26.6.3",

--- a/specification/files/ryuou201409020101.jkf.json
+++ b/specification/files/ryuou201409020101.jkf.json
@@ -1,0 +1,1 @@
+../../test/files/jkf/ryuou201409020101.jkf

--- a/specification/files/same_move_minimal.jkf.json
+++ b/specification/files/same_move_minimal.jkf.json
@@ -1,0 +1,1 @@
+../../test/files/jkf/same_move_minimal.jkf

--- a/specification/json-kifu-format.schema.json
+++ b/specification/json-kifu-format.schema.json
@@ -1,0 +1,515 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://github.com/na2hiro/json-kifu-format",
+  "$ref": "#/$defs/record",
+  "$defs": {
+    "record": {
+      "title": "json-kifu-format",
+      "type": "object",
+      "properties": {
+        "header": {
+          "description": "ヘッダ情報。キーはKI2，KIF等の日本語のものに準ずる．(例: \"場所\", \"先手\")",
+          "$ref": "#/$defs/header"
+        },
+        "initial": {
+          "description": "初期局面。nullの場合は平手を表す",
+          "$ref": "#/$defs/initial"
+        },
+        "moves": {
+          "description": "n番目はn手目の棋譜(0番目は初期局面のコメント用)。",
+          "$ref": "#/$defs/moves"
+        }
+      },
+      "required": [
+        "header",
+        "moves"
+      ],
+      "additionalProperties": false
+    },
+    "initial": {
+      "title": "初期状態",
+      "type": [
+        "object",
+        "null"
+      ],
+      "properties": {
+        "preset": {
+          "description": "手合名",
+          "$ref": "#/$defs/preset"
+        },
+        "data": {
+          "description": "初期局面データ。手合名がOTHERの時に使用する",
+          "$ref": "#/$defs/initialData"
+        }
+      },
+      "required": [
+        "preset"
+      ],
+      "additionalProperties": false
+    },
+    "header": {
+      "title": "ヘッダ情報",
+      "type": "object",
+      "additionalProperties": {
+        "type": "string"
+      }
+    },
+    "preset": {
+      "title": "手合情報",
+      "description": "KIFでサポートされている手合情報。順に、平手、香落ち、右香落ち、角落ち、飛車落ち、飛香落ち、二枚落ち、三枚落ち、四枚落ち、五枚落ち、左五枚落ち、六枚落ち、左七枚落ち、右七枚落ち、八枚落ち、十枚落ち、その他、を表す。",
+      "enum": [
+        "HIRATE",
+        "KY",
+        "KY_R",
+        "KA",
+        "HI",
+        "HIKY",
+        "2",
+        "3",
+        "4",
+        "5",
+        "5_L",
+        "6",
+        "7_L",
+        "7_R",
+        "8",
+        "10",
+        "OTHER"
+      ]
+    },
+    "initialData": {
+      "title": "初期局面のデータ",
+      "type": [
+        "object",
+        "null"
+      ],
+      "properties": {
+        "color": {
+          "description": "初手の手番",
+          "$ref": "#/$defs/color"
+        },
+        "board": {
+          "description": "盤上の駒の配置",
+          "$ref": "#/$defs/initialBoard"
+        },
+        "hands": {
+          "description": "0番目が先手，1番目が後手の持駒",
+          "$ref": "#/$defs/hands"
+        }
+      },
+      "required": [
+        "color",
+        "board",
+        "hands"
+      ]
+    },
+    "initialBoard": {
+      "title": "初期状態の盤面",
+      "oneOf": [
+        {
+          "description": "駒がない場合",
+          "type": "object",
+          "additionalProperties": false
+        },
+        {
+          "description": "盤上の駒。board[x-1][y-1]に(x,y)の駒情報",
+          "$ref": "#/$defs/board"
+        }
+      ]
+    },
+    "board": {
+      "title": "盤",
+      "type": "array",
+      "items": {
+        "$ref": "#/$defs/column"
+      }
+    },
+    "column": {
+      "title": "盤の列",
+      "type": "array",
+      "items": {
+        "$ref": "#/$defs/square"
+      }
+    },
+    "square": {
+      "title": "盤の升",
+      "type": "object",
+      "properties": {
+        "color": {
+          "description": "先手/後手",
+          "oneOf": [
+            {
+              "$ref": "#/$defs/color"
+            },
+            {
+              "type": "null"
+            }
+          ]
+        },
+        "kind": {
+          "description": "駒の種類",
+          "oneOf": [
+            {
+              "$ref": "#/$defs/kind"
+            },
+            {
+              "type": "null"
+            }
+          ]
+        }
+      },
+      "additionalProperties": false
+    },
+    "moves": {
+      "title": "指し手のリスト",
+      "type": "array",
+      "prefixItems": [
+        {
+          "$ref": "#/$defs/initialComment"
+        }
+      ],
+      "items": {
+        "$ref": "#/$defs/moveWithForksAndInfo"
+      }
+    },
+    "initialComment": {
+      "title": "初期局面のコメント",
+      "type": "object",
+      "properties": {
+        "comment": {
+          "type": "string"
+        }
+      }
+    },
+    "hands": {
+      "title": "先後双方の持駒",
+      "type": "array",
+      "minItems": 2,
+      "maxItems": 2,
+      "items": {
+        "description": "駒種がkey, 枚数がvalueの連想配列",
+        "$ref": "#/$defs/hand"
+      }
+    },
+    "hand": {
+      "title": "持駒",
+      "type": "object",
+      "additionalProperties": false,
+      "properties": {
+        "FU": {
+          "type": "integer"
+        },
+        "KY": {
+          "type": "integer"
+        },
+        "KE": {
+          "type": "integer"
+        },
+        "GI": {
+          "type": "integer"
+        },
+        "KI": {
+          "type": "integer"
+        },
+        "KA": {
+          "type": "integer"
+        },
+        "HI": {
+          "type": "integer"
+        },
+        "OU": {
+          "type": "integer"
+        },
+        "TO": {
+          "type": "integer"
+        },
+        "NY": {
+          "type": "integer"
+        },
+        "NK": {
+          "type": "integer"
+        },
+        "NG": {
+          "type": "integer"
+        },
+        "UM": {
+          "type": "integer"
+        },
+        "RY": {
+          "type": "integer"
+        }
+      }
+    },
+    "color": {
+      "title": "陣営",
+      "description": "先手：0、後手：1",
+      "enum": [
+        0,
+        1
+      ]
+    },
+    "moveWithForksAndInfo": {
+      "title": "指し手",
+      "type": "object",
+      "properties": {
+        "comments": {
+          "description": "コメント",
+          "$ref": "#/$defs/comments"
+        },
+        "move": {
+          "description": "駒の動き",
+          "$ref": "#/$defs/move"
+        },
+        "time": {
+          "description": "消費時間",
+          "$ref": "#/$defs/consumption"
+        },
+        "special": {
+          "description": "特殊棋譜。それぞれの意味はCSA標準棋譜ファイル形式 (V2.2) に準拠する。",
+          "$ref": "#/$defs/special"
+        },
+        "forks": {
+          "description": "分岐。任意の長さの分岐を任意個格納する．分岐の初手はこのforksを持つ棋譜の代替の手とする(次の手ではなく)",
+          "$ref": "#/$defs/forks"
+        }
+      },
+      "additionalProperties": false
+    },
+    "special": {
+      "title": "特殊棋譜",
+      "enum": [
+        "TORYO",
+        "CHUDAN",
+        "SENNICHITE",
+        "TIME_UP",
+        "ILLEGAL_MOVE",
+        "+ILLEGAL_ACTION",
+        "-ILLEGAL_ACTION",
+        "JISHOGI",
+        "KACHI",
+        "HIKIWAKE",
+        "MATTA",
+        "TSUMI",
+        "FUZUMI",
+        "ERROR",
+        null
+      ]
+    },
+    "forks": {
+      "title": "分岐群",
+      "type": [
+        "array",
+        "null"
+      ],
+      "items": {
+        "$ref": "#/$defs/fork"
+      }
+    },
+    "fork": {
+      "title": "分岐",
+      "type": "array",
+      "items": {
+        "$ref": "#/$defs/moveWithForksAndInfo"
+      }
+    },
+    "consumption": {
+      "title": "消費時間",
+      "type": [
+        "object",
+        "null"
+      ],
+      "properties": {
+        "now": {
+          "description": "1手",
+          "$ref": "#/$defs/time"
+        },
+        "total": {
+          "description": "合計",
+          "$ref": "#/$defs/time"
+        }
+      },
+      "required": [
+        "now",
+        "total"
+      ],
+      "additionalProperties": false
+    },
+    "move": {
+      "title": "指し手",
+      "type": [
+        "object",
+        "null"
+      ],
+      "properties": {
+        "color": {
+          "description": "先手/後手",
+          "$ref": "#/$defs/color"
+        },
+        "from": {
+          "description": "移動元。打った場合はなし",
+          "oneOf": [
+            {
+              "$ref": "#/$defs/placeFormat"
+            },
+            {
+              "type": "null"
+            }
+          ]
+        },
+        "to": {
+          "description": "移動先",
+          "$ref": "#/$defs/placeFormat"
+        },
+        "piece": {
+          "description": "駒の種類",
+          "$ref": "#/$defs/kind"
+        },
+        "same": {
+          "description": "直前と同じ場合",
+          "type": [
+            "boolean",
+            "null"
+          ]
+        },
+        "promote": {
+          "description": "成るかどうか。true:成, false:不成, 無いかnull:どちらでもない",
+          "type": [
+            "boolean",
+            "null"
+          ]
+        },
+        "capture": {
+          "description": "取った駒の種類",
+          "oneOf": [
+            {
+              "$ref": "#/$defs/capturablekind"
+            },
+            {
+              "type": "null"
+            }
+          ]
+        },
+        "relative": {
+          "description": "相対情報",
+          "oneOf": [
+            {
+              "$ref": "#/$defs/relative"
+            },
+            {
+              "type": "null"
+            }
+          ]
+        }
+      },
+      "required": [
+        "color",
+        "to",
+        "piece"
+      ],
+      "additionalProperties": false
+    },
+    "comments": {
+      "title": "コメント",
+      "oneOf": [
+        {
+          "type": "null"
+        },
+        {
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        }
+      ]
+    },
+    "relative": {
+      "title": "相対情報",
+      "type": "string",
+      "pattern": "[LCR]|[UMD]|[LCR][UD]|[LR]M|H"
+    },
+    "time": {
+      "title": "時間",
+      "type": "object",
+      "properties": {
+        "h": {
+          "description": "時",
+          "type": [
+            "integer",
+            "null"
+          ]
+        },
+        "m": {
+          "description": "分",
+          "type": "integer"
+        },
+        "s": {
+          "description": "秒",
+          "type": "integer"
+        }
+      },
+      "required": [
+        "m",
+        "s"
+      ],
+      "additionalProperties": false
+    },
+    "placeFormat": {
+      "title": "座標",
+      "type": "object",
+      "properties": {
+        "x": {
+          "description": "1から9",
+          "type": "integer"
+        },
+        "y": {
+          "description": "一から九",
+          "type": "integer"
+        }
+      },
+      "required": [
+        "x",
+        "y"
+      ],
+      "additionalProperties": false
+    },
+    "kind": {
+      "title": "駒の種類",
+      "description": "CSA標準棋譜ファイル形式 (V2.2) の表記を使用している。",
+      "enum": [
+        "FU",
+        "KY",
+        "KE",
+        "GI",
+        "KI",
+        "KA",
+        "HI",
+        "OU",
+        "TO",
+        "NY",
+        "NK",
+        "NG",
+        "UM",
+        "RY"
+      ]
+    },
+    "capturablekind": {
+      "title": "持駒に加えることができる駒の種類",
+      "description": "kindの部分集合である。",
+      "enum": [
+        "FU",
+        "KY",
+        "KE",
+        "GI",
+        "KI",
+        "KA",
+        "HI",
+        "TO",
+        "NY",
+        "NK",
+        "NG",
+        "UM",
+        "RY"
+      ]
+    }
+  }
+}


### PR DESCRIPTION
json-kifu-formatの仕様を記述するJSON Schemaファイルを追加します。

json-kifu-formatのJSON Schemaファイルが用意されていることにより、json-kifu-format形式の棋譜が正しい形式に則っているかどうかの検査を機械的に行うことができると考えられます。

- [x] `README.md` の記述からあらかたのJSON Schemaを書き出してみる
- [x] JSON Schemaファイル名の検討
- [x] より厳密な型や制約をJSON Schemaで表現する
- [x] JSON Schema自体のajvによる検証
- [x] 例に対して検査が通るかの確認、またそれに伴うJSON Schemaファイル（または既存のファイル）の修正 (#41, #56)
- [x] readmeへの追記
- [x] `description` 属性での説明を見直す
- [x] #54 （[`7_L`, `7_R` の追加][pr54]）への追従

# 参照

* [json-schema-format > JSONの形式 (Version 1.0)][jkf]
* [JSON Schema: A Media Type for Describing JSON Documents draft-bhutton-json-schema-00][core]
* [JSON Schema Validation: A Vocabulary for Structural Validation of JSON draft-bhutton-json-schema-validation-00][validation]
* [Standard ECMA-262 5.1 Edition / June 2011 ECMAScript® Language Specification][ecma]
* [CSA標準棋譜ファイル形式 (V2.2)][csa]
* [ajv-cli][]

[jkf]: https://github.com/na2hiro/json-kifu-format#json%E3%81%AE%E5%BD%A2%E5%BC%8F-version-10
[core]: https://json-schema.org/draft/2020-12/json-schema-core.html
[csa]: http://www2.computer-shogi.org/protocol/record_v22.html
[validation]: https://json-schema.org/draft/2020-12/json-schema-validation.html
[ecma]: https://262.ecma-international.org/5.1/
[pr54]: https://github.com/na2hiro/json-kifu-format/pull/54/files#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5R97
[ajv-cli]: https://ajv.js.org/packages/ajv-cli.html